### PR TITLE
Append to INC_DIR and LIB_DIR to allow specifying custom installation paths

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -45,5 +45,5 @@ endif
 .c.o:
 	$(CC) -c $< -o $@ $(CFLAGS) $(CFLAGS_WARN) $(CFLAGS_ALWAYS) $(INC_DIR) $(BIT)
 
-INC_DIR= -I../src -I../../xbyak -I../include
-LIB_DIR= -L../lib
+INC_DIR+= -I../src -I../../xbyak -I../include
+LIB_DIR+= -L../lib


### PR DESCRIPTION
This is useful for building ate-pairing with MacPorts-installed libgmp (it is then installed in /opt/local/{include,lib}).
