### PR TITLE
remove status printing, read Fp2 from file

### DIFF
--- a/include/bn.h
+++ b/include/bn.h
@@ -565,6 +565,11 @@ struct Fp2T : public mie::local::addsubmul<Fp2T<T>
 		return a_ == rhs.a_ && b_ == rhs.b_;
 	}
 	bool operator!=(const Fp2T& rhs) const { return !operator==(rhs); }
+	
+	void set(const char* val) {
+	  std::stringstream sstr(val);
+	  sstr >> *this;
+	}
 
 	// z = x * b
 	static inline void mul_Fp_0C(Fp2T& z, const Fp2T& x, const Fp& b)

--- a/include/zm.h
+++ b/include/zm.h
@@ -88,6 +88,8 @@ inline std::istream& getDigits(std::istream& is, std::string& str, bool allowNeg
 	char c;
 	while (is >> c) {
 		if (('0' <= c && c <= '9') /* digits */
+		  || ('a' <= c && c <= 'f') /* lowercase hex */
+		  || ('A' <= c && c <= 'F') /* uppercase hex */
 		  || (pos == 1 && (str[0] == '0' && c == 'x')) /* 0x.. */
 		  || (allowNegative && pos == 0 && c == '-')) { /* -digits */
 			str.push_back(c);

--- a/src/zm2.cpp
+++ b/src/zm2.cpp
@@ -3603,7 +3603,7 @@ void Fp::setModulo(const mie::Vuint& p, int mode, bool useMulx)
 		exit(1);
 	}
 	if (scipr) {
-		fprintf(stderr, "support SNARK\n");
+		//fprintf(stderr, "support SNARK\n");
 	}
 	static bool init = false;
 	if (init) return;


### PR DESCRIPTION
 - I removed the "support SNARK" message printed when compiling with SNARK support
 - (When compiling with SNARK support.) It is not possible to read/write Ec2 points using >> and <<. This is because the << operator by default prints hex coordinates, and the >> operator of the underlying Fp2 calls getDigits, which does not support hexadecimal digits. I patched getDigits so that hex characters are also supported. With this patch, calling operator<< and operator>> on Ec2 points works.