### PR TITLE
Enable using ate-pairing as a shared library

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -9,7 +9,7 @@ CP = cp -f
 AR = ar r
 MKDIR=mkdir -p
 RM=rm -f
-CFLAGS = -O3 -fomit-frame-pointer -DNDEBUG -msse2 -mfpmath=sse -march=native
+CFLAGS = -fPIC -O3 -fomit-frame-pointer -DNDEBUG -msse2 -mfpmath=sse -march=native
 CFLAGS_WARN=-Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith #-Wswitch-enum -Wstrict-aliasing=2
 CFLAGS_ALWAYS = -D_FILE_OFFSET_BITS=64 -DMIE_ATE_USE_GMP
 LDFLAGS = -lm -lzm $(LIB_DIR) -lgmp -lgmpxx


### PR DESCRIPTION
Currently ate-pairing is built without support for position-independent-code so external code can't use it as a shared library. This commit enables such use by adding -fPIC option to CFLAGS.
