### PR TITLE
make mie::Fp trivially copyable

### DIFF
--- a/include/zm2.h
+++ b/include/zm2.h
@@ -40,10 +40,6 @@ public:
 	{
 		std::copy(x, x + N, v_);
 	}
-	MIE_FORCE_INLINE Fp(const Fp& x)
-	{
-		set(x);
-	}
 	Fp(const mie::Vuint& rhs)
 	{
 		set(rhs);
@@ -79,10 +75,6 @@ public:
 		y *= getMontgomeryR();
 		y %= getModulo();
 		setDirect(*this, y);
-	}
-	MIE_FORCE_INLINE void set(const Fp& x)
-	{
-		std::copy(x.v_, x.v_ + N, v_);
 	}
 	static inline int compare(const Fp& x, const Fp& y)
 	{


### PR DESCRIPTION
There is no need to define copy constructor as the default one does the same thing. That change however makes `std::is_trivially_copyable<mie::Fp>::value` true.

I'm writing Haskell bindings for parts of libsnark and dealing with trivially copyable classes allows to manage memory for them more efficiently. You can allocate a raw block of memory, copy existing object to it with `memcpy` and have a valid copy, hence you can make use of memory management techniques of the language you bind to.
